### PR TITLE
[readme] Update Cockroach instructions and paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,28 +38,30 @@ To set up CockroachDB for use with cmswww, follow these steps:
      Replace `<install dir>` with the installation location for CockroachDB on your machine:
 
          cd <install dir>
-         mkdir ~/cmswww/data/testnet3/cockroachdb
+         mkdir ~/.cmswww/data/testnet3/cockroachdb
 
-         cockroach cert create-ca --certs-dir="~/cmswww/data/testnet3/cockroachdb" --ca-key="<install dir>/ca.key" --allow-ca-key-reuse
+         cockroach cert create-ca --certs-dir="~/.cmswww/data/testnet3/cockroachdb" --ca-key="<install dir>/ca.key" --allow-ca-key-reuse
 
-         cockroach cert create-client root --certs-dir="~/cmswww/data/testnet3/cockroachdb" --ca-key="<install dir>/ca.key"
+         cockroach cert create-client root --certs-dir="~/.cmswww/data/testnet3/cockroachdb" --ca-key="<install dir>/ca.key"
 
-         cockroach cert create-node localhost --certs-dir="~/cmswww/data/testnet3/cockroachdb" --ca-key="<install dir>/ca.key"
+         cockroach cert create-node localhost --certs-dir="~/.cmswww/data/testnet3/cockroachdb" --ca-key="<install dir>/ca.key"
 
-         cockroach user set cmswwwuser --certs-dir="~/cmswww/data/testnet3/cockroachdb"
+         cockroach start --host=localhost --http-host=localhost --certs-dir="~/.cmswww/data/testnet3/cockroachdb"
 
-         cockroach cert create-client cmswwwuser --certs-dir="~/cmswww/data/testnet3/cockroachdb" --ca-key="<install dir>/ca.key"
+         cockroach user set cmswwwuser --certs-dir="~/.cmswww/data/testnet3/cockroachdb"
 
-         cockroach sql --certs-dir="~/cmswww/data/testnet3/cockroachdb" -e 'CREATE DATABASE cmswww'
+         cockroach cert create-client cmswwwuser --certs-dir="~/.cmswww/data/testnet3/cockroachdb" --ca-key="<install dir>/ca.key"
 
-         cockroach sql --certs-dir="~/cmswww/data/testnet3/cockroachdb" -e 'GRANT ALL ON DATABASE cmswww TO cmswwwuser'
+         cockroach sql --certs-dir="~/.cmswww/data/testnet3/cockroachdb" -e 'CREATE DATABASE cmswww'
 
-         cockroach sql --user=cmswwwuser --certs-dir="~/cmswww/data/testnet3/cockroachdb" -e 'GRANT ALL ON DATABASE cmswww TO cmswwwuser'
+         cockroach sql --certs-dir="~/.cmswww/data/testnet3/cockroachdb" -e 'GRANT ALL ON DATABASE cmswww TO cmswwwuser'
+
+         cockroach sql --user=cmswwwuser --certs-dir="~/.cmswww/data/testnet3/cockroachdb" -e 'GRANT ALL ON DATABASE cmswww TO cmswwwuser'
 
    3. Start CockroachDB.
 
           cd <install dir>
-          cockroach start --host=localhost --http-host=localhost --certs-dir="~/cmswww/data/testnet3/cockroachdb"
+          cockroach start --host=localhost --http-host=localhost --certs-dir="~/.cmswww/data/testnet3/cockroachdb"
 
 #### 2. Clone this repository and [decred/politeia](https://github.com/decred/politeia).
 


### PR DESCRIPTION
Fixes paths to use ~/.cmswww instead of ~/cmswww.

Also adds an extra step to start the db to be able to set the users and run the sql commands.