### PR TITLE
Add ability to fetch dcrusd monthly rate.

### DIFF
--- a/cmswww/api/v1/route_protocol.go
+++ b/cmswww/api/v1/route_protocol.go
@@ -29,6 +29,7 @@ const (
 	RouteSetInvoiceStatus          = "/invoice/status"
 	RouteUpdateInvoicePayment      = "/invoice/payments/update"
 	RoutePolicy                    = "/policy"
+	RouteRate                      = "/rate"
 )
 
 var (
@@ -405,6 +406,16 @@ type InvoicePolicyField struct {
 	Name     string            `json:"name"`
 	Type     InvoiceFieldTypeT `json:"type"`
 	Required bool              `json:"required"`
+}
+
+type Rate struct {
+	Month uint16 `json:"month"`
+	Year  uint16 `json:"year"`
+}
+
+type RateReply struct {
+	DCRUSDRate    float64 `json:"dcrusdrate"`
+	IsDataMissing bool    `json:"isdatamissing"`
 }
 
 // UserDetails fetches a user's details by their id, email, or username.

--- a/cmswww/cmd/cmswwwcli/commands/cmswwwcli.go
+++ b/cmswww/cmd/cmswwwcli/commands/cmswwwcli.go
@@ -41,6 +41,7 @@ type Options struct {
 	ReviewInvoices          ReviewInvoicesCmd          `command:"reviewinvoices" description:"Generates a list of submitted invoices that are ready for initial review.\n\n           Parameters: <month> <year>\n  --------------------------------------"`
 	PayInvoices             PayInvoicesCmd             `command:"payinvoices" description:"Generates a list of unpaid invoices that are ready for payment.\n\n           Parameters: <month> <year> <DCR-USD rate>\n  --------------------------------------"`
 	UpdateInvoicePayment    UpdateInvoicePaymentCmd    `command:"updateinvoicepayment" description:"Updates a generated invoice payment with the transaction information.\n\n           Parameters: <invoice token> <address> <amount in atoms> <transaction id>\n  --------------------------------------"`
+	GetRate                 GetRateCmd                 `command:"getrate" description:"Calculates the rate for the given month and year.\n\n           Parameters: <month> <year>\n  --------------------------------------"`
 }
 
 var Ctx *client.Ctx

--- a/cmswww/cmd/cmswwwcli/commands/getrate.go
+++ b/cmswww/cmd/cmswwwcli/commands/getrate.go
@@ -1,0 +1,32 @@
+package commands
+
+import (
+	"github.com/decred/contractor-mgmt/cmswww/api/v1"
+)
+
+type GetRateCmd struct {
+	Args struct {
+		Month string `positional-arg-name:"month"`
+		Year  uint16 `positional-arg-name:"year"`
+	} `positional-args:"true" required:"true"`
+}
+
+func (cmd *GetRateCmd) Execute(args []string) error {
+	err := InitialVersionRequest()
+	if err != nil {
+		return err
+	}
+
+	month, err := ParseMonth(cmd.Args.Month)
+	if err != nil {
+		return err
+	}
+
+	r := v1.Rate{
+		Month: month,
+		Year:  cmd.Args.Year,
+	}
+
+	var rr v1.RateReply
+	return Ctx.Get(v1.RouteRate, r, &rr)
+}

--- a/cmswww/log.go
+++ b/cmswww/log.go
@@ -43,12 +43,14 @@ var (
 
 	log            = backendLog.Logger("CWWW")
 	cockroachdbLog = backendLog.Logger("CRDB")
+	rateCalculatorLog = backendLog.Logger("RCLC")
 )
 
 // subsystemLoggers maps each subsystem identifier to its associated logger.
 var subsystemLoggers = map[string]slog.Logger{
 	"CWWW": log,
 	"CRDB": cockroachdbLog,
+	"RCLC": rateCalculatorLog,
 }
 
 // initLogRotator initializes the logging rotater to write logs to logFile and

--- a/cmswww/log.go
+++ b/cmswww/log.go
@@ -41,8 +41,8 @@ var (
 	// application shutdown.
 	logRotator *rotator.Rotator
 
-	log            = backendLog.Logger("CWWW")
-	cockroachdbLog = backendLog.Logger("CRDB")
+	log               = backendLog.Logger("CWWW")
+	cockroachdbLog    = backendLog.Logger("CRDB")
 	rateCalculatorLog = backendLog.Logger("RCLC")
 )
 

--- a/cmswww/rate.go
+++ b/cmswww/rate.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/decred/contractor-mgmt/cmswww/api/v1"
+	"github.com/decred/contractor-mgmt/cmswww/database"
+)
+
+func (c *cmswww) HandleRate(
+	req interface{},
+	user *database.User,
+	w http.ResponseWriter,
+	r *http.Request,
+) (interface{}, error) {
+	rate := req.(*v1.Rate)
+	dcrUSDRate, isDataMissing, err := c.rateCalculator.CalculateRateForMonth(
+		time.Month(rate.Month), int(rate.Year))
+	if err != nil {
+		return nil, err
+	}
+
+	return &v1.RateReply{
+		DCRUSDRate:    dcrUSDRate,
+		IsDataMissing: isDataMissing,
+	}, nil
+}

--- a/cmswww/ratecalc/convert.go
+++ b/cmswww/ratecalc/convert.go
@@ -1,0 +1,59 @@
+package ratecalc
+
+import (
+	"strconv"
+)
+
+func convertCandlestickToStringArray(candlestick *Candlestick) []string {
+	return []string{
+		strconv.FormatInt(candlestick.Timestamp, 10),
+		strconv.FormatInt(candlestick.Granularity, 10),
+		strconv.FormatFloat(candlestick.Open, 'f', 8, 64),
+		strconv.FormatFloat(candlestick.Close, 'f', 8, 64),
+		strconv.FormatFloat(candlestick.High, 'f', 8, 64),
+		strconv.FormatFloat(candlestick.Low, 'f', 8, 64),
+		strconv.FormatFloat(candlestick.Volume, 'f', 8, 64),
+	}
+}
+
+func convertStringArrayToCandlestick(record []string) (*Candlestick, error) {
+	var candlestick Candlestick
+
+	var err error
+	candlestick.Timestamp, err = strconv.ParseInt(record[0], 10, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	candlestick.Granularity, err = strconv.ParseInt(record[1], 10, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	candlestick.Open, err = strconv.ParseFloat(record[2], 64)
+	if err != nil {
+		return nil, err
+	}
+
+	candlestick.Close, err = strconv.ParseFloat(record[3], 64)
+	if err != nil {
+		return nil, err
+	}
+
+	candlestick.High, err = strconv.ParseFloat(record[4], 64)
+	if err != nil {
+		return nil, err
+	}
+
+	candlestick.Low, err = strconv.ParseFloat(record[5], 64)
+	if err != nil {
+		return nil, err
+	}
+
+	candlestick.Volume, err = strconv.ParseFloat(record[6], 64)
+	if err != nil {
+		return nil, err
+	}
+
+	return &candlestick, nil
+}

--- a/cmswww/ratecalc/log.go
+++ b/cmswww/ratecalc/log.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2013-2018 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package ratecalc
+
+import "github.com/decred/slog"
+
+// log is a logger that is initialized with no output filters.  This
+// means the package will not perform any logging by default until the caller
+// requests it.
+var log = slog.Disabled
+
+// DisableLog disables all library log output.  Logging output is disabled
+// by default until either UseLogger or SetLogWriter are called.
+func DisableLog() {
+	log = slog.Disabled
+}
+
+// UseLogger uses a specified Logger to output package logging info.
+// This should be used in preference to SetLogWriter if the caller is also
+// using slog.
+func UseLogger(logger slog.Logger) {
+	log = logger
+}

--- a/cmswww/ratecalc/ratecalc.go
+++ b/cmswww/ratecalc/ratecalc.go
@@ -139,7 +139,7 @@ func (c *Calculator) getMostRecentIntervalFromDataFile(
 	if err != nil {
 		return time.Time{}, err
 	}
-	if records == nil || len(records) == 0 {
+	if len(records) == 0 {
 		return time.Time{}, nil
 	}
 

--- a/cmswww/ratecalc/ratecalc.go
+++ b/cmswww/ratecalc/ratecalc.go
@@ -1,0 +1,439 @@
+package ratecalc
+
+import (
+	"crypto/tls"
+	"encoding/csv"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+type Calculator struct {
+	sync.RWMutex // lock for file reading/writing
+
+	dataDir    string
+	httpClient *http.Client
+}
+
+type Candlestick struct {
+	Timestamp   int64   // Timestamp of this interval
+	Granularity int64   // Interval in minutes
+	Open        float64 // Price at interval start
+	Close       float64 // Price at interval end
+	High        float64 // Highest price during this interval
+	Low         float64 // Lowest price during this interval
+	Volume      float64 // Volume for this interval
+}
+
+var (
+	interval = time.Minute * 15
+
+	ErrNonExistentLogFile = fmt.Errorf("non-existent log file")
+	ErrNoRecordsFound     = fmt.Errorf("no records found")
+)
+
+func fileExists(name string) bool {
+	if _, err := os.Stat(name); err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func firstDayOfMonth(month time.Month, year int) time.Time {
+	return time.Date(year, month, 1, 0, 0, 0, 0, time.Local)
+}
+
+func New(dataDir string) *Calculator {
+	calc := Calculator{
+		dataDir: dataDir,
+	}
+	go calc.init()
+	return &calc
+}
+
+func (c *Calculator) getLogFilename(month time.Month, year int) string {
+	return filepath.Join(c.dataDir,
+		fmt.Sprintf("rate-candlesticks-%v-%v.csv", year, month))
+}
+
+func (c *Calculator) init() {
+	c.httpClient = &http.Client{
+		Transport: &http.Transport{
+			IdleConnTimeout: 60 * time.Second,
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: false,
+			},
+		},
+	}
+
+	c.updateCandlesticks()
+	ticker := time.NewTicker(interval)
+	go func() {
+		for range ticker.C {
+			c.updateCandlesticks()
+		}
+	}()
+}
+
+func (c *Calculator) updateCandlesticks() {
+	log.Infof("Updating candlesticks")
+
+	t := time.Now()
+	fifthDayOfMonth := firstDayOfMonth(t.Month(), t.Year()).AddDate(0, 0, 4)
+	if t.Before(fifthDayOfMonth) {
+		lastDayOfPrevMonth := firstDayOfMonth(t.Month(), t.Year()).Add(
+			time.Nanosecond * -1)
+
+		for {
+			shouldContinue, err := c.updateCandlesticksForMonth(lastDayOfPrevMonth.Month(),
+				lastDayOfPrevMonth.Year(), true)
+			if err != nil {
+				log.Error(err)
+				break
+			}
+			if !shouldContinue {
+				break
+			}
+		}
+	}
+
+	for {
+		shouldContinue, err := c.updateCandlesticksForMonth(t.Month(), t.Year(), false)
+		if err != nil {
+			log.Error(err)
+			break
+		}
+		if !shouldContinue {
+			break
+		}
+	}
+}
+
+func (c *Calculator) getMostRecentIntervalFromLogFile(
+	month time.Month,
+	year int,
+) (time.Time, error) {
+	filename := c.getLogFilename(month, year)
+
+	records, err := c.getRecords(filename)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if records == nil || len(records) == 0 {
+		return time.Time{}, nil
+	}
+
+	lastRecord := records[len(records)-1]
+	lastInterval, err := convertStringArrayToCandlestick(lastRecord)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("could not convert record to Interval: %v", err)
+	}
+
+	return time.Unix(lastInterval.Timestamp, 0), nil
+}
+
+func (c *Calculator) shouldUpdateLogFile(
+	intervalTime time.Time,
+	month time.Month,
+	year int,
+) bool {
+	firstDayOfNextMonth := firstDayOfMonth(month, year).AddDate(0, 1, 0)
+	lastIntervalOfMonth := firstDayOfNextMonth.Add(interval * -1)
+
+	// If the most recent time is the last interval of the month,
+	// then we have nothing to do.
+	if !intervalTime.Before(lastIntervalOfMonth) {
+		return false
+	}
+
+	// If the most recent time is within the interval duration of the current
+	// time, then we have nothing to do.
+	if intervalTime.After(time.Now().Add(interval)) {
+		return false
+	}
+
+	return true
+}
+
+func (c *Calculator) getDataIndices(
+	currIntervalTime time.Time,
+	dcrBTCData, btcUSDData []Candlestick,
+) (time.Time, int, int) {
+	// Ensure that the current interval time falls within the range
+	// of DCR-BTC data.
+	dcrBTCFirstIntervalTime := time.Unix(dcrBTCData[0].Timestamp, 0)
+	if currIntervalTime.Before(dcrBTCFirstIntervalTime) {
+		currIntervalTime = dcrBTCFirstIntervalTime
+	}
+
+	// Ensure that the current interval time falls within the range
+	// of BTC-USD data.
+	btcUSDFirstIntervalTime := time.Unix(btcUSDData[0].Timestamp, 0)
+	if currIntervalTime.Before(btcUSDFirstIntervalTime) {
+		currIntervalTime = btcUSDFirstIntervalTime
+	}
+
+	var (
+		dcrBTCIdx int
+		btcUSDIdx int
+	)
+	for dcrBTCIdx < len(dcrBTCData) && btcUSDIdx < len(btcUSDData) {
+		dcrBTCCandlestick := dcrBTCData[dcrBTCIdx]
+		btcUSDCandlestick := btcUSDData[btcUSDIdx]
+
+		// Ensure the timestamps from the 2 datasets are aligned.
+		if dcrBTCCandlestick.Timestamp < btcUSDCandlestick.Timestamp {
+			dcrBTCIdx++
+			continue
+		} else if btcUSDCandlestick.Timestamp < dcrBTCCandlestick.Timestamp {
+			btcUSDIdx++
+			continue
+		}
+
+		// Find the indices for the current interval.
+		if dcrBTCCandlestick.Timestamp < currIntervalTime.Unix() {
+			dcrBTCIdx++
+			btcUSDIdx++
+			continue
+		}
+
+		return currIntervalTime, dcrBTCIdx, btcUSDIdx
+	}
+
+	// The current interval is past the range of data.
+	return currIntervalTime, -1, -1
+}
+
+func (c *Calculator) fetchData(
+	month time.Month,
+	year int,
+	currIntervalTime time.Time,
+) ([][]Candlestick, time.Time, error) {
+	var candlesticks [][]Candlestick
+
+	if currIntervalTime.After(time.Now().Add(interval)) {
+		return candlesticks, currIntervalTime, nil
+	}
+
+	dcrBTCData, err := c.getDCRBTCData(currIntervalTime, interval)
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("could not fetch dcr-btc data: %v",
+			err)
+	}
+
+	if len(dcrBTCData) == 0 {
+		// No data was returned.
+		return candlesticks, currIntervalTime, nil
+	}
+
+	btcUSDData, err := c.getBTCUSDData(currIntervalTime, interval)
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("could not fetch btc-usd data: %v",
+			err)
+	}
+
+	if len(btcUSDData) == 0 {
+		// No data was returned.
+		return candlesticks, currIntervalTime, nil
+	}
+
+	// Get the indices of the data which match the current interval time.
+	var (
+		dcrBTCIdx int
+		btcUSDIdx int
+	)
+	currIntervalTime, dcrBTCIdx, btcUSDIdx = c.getDataIndices(
+		currIntervalTime, dcrBTCData, btcUSDData)
+	if dcrBTCIdx < 0 {
+		return candlesticks, currIntervalTime, nil
+	}
+
+	for {
+		if dcrBTCIdx >= len(dcrBTCData) || btcUSDIdx >= len(btcUSDData) {
+			break
+		}
+
+		candlesticks = append(candlesticks, []Candlestick{
+			dcrBTCData[dcrBTCIdx],
+			btcUSDData[btcUSDIdx],
+		})
+		currIntervalTime = time.Unix(dcrBTCData[dcrBTCIdx].Timestamp, 0)
+
+		dcrBTCIdx++
+		btcUSDIdx++
+	}
+
+	return candlesticks, currIntervalTime, nil
+}
+
+func (c *Calculator) addDataToLogFile(
+	month time.Month,
+	year int,
+	data [][]Candlestick,
+) error {
+	filename := c.getLogFilename(month, year)
+	file, err := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY|os.O_CREATE,
+		0600)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	writer := csv.NewWriter(file)
+	defer writer.Flush()
+
+	for _, candlesticks := range data {
+		dcrBTCCandlestick := convertCandlestickToStringArray(&candlesticks[0])
+		btcUSDCandlestick := convertCandlestickToStringArray(&candlesticks[1])
+		err := writer.Write(append(dcrBTCCandlestick, btcUSDCandlestick...))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *Calculator) updateCandlesticksForMonth(
+	month time.Month,
+	year int,
+	ignoreIfNonexistent bool,
+) (bool, error) {
+	currIntervalTime, err := c.getMostRecentIntervalFromLogFile(month, year)
+	if err != nil {
+		return false, err
+	}
+	if currIntervalTime.IsZero() {
+		if ignoreIfNonexistent {
+			return false, nil
+		}
+
+		currIntervalTime = firstDayOfMonth(month, year)
+	} else {
+		// If the current interval time is non-zero, then it's the most recent
+		// interval found in the log file, so start at the next interval.
+		currIntervalTime = currIntervalTime.Add(interval)
+	}
+
+	if !c.shouldUpdateLogFile(currIntervalTime, month, year) {
+		return false, nil
+	}
+
+	data, currIntervalTime, err := c.fetchData(month, year, currIntervalTime)
+	if err != nil {
+		return false, err
+	}
+
+	if len(data) == 0 {
+		// No data was returned.
+		return false, nil
+	}
+
+	err = c.addDataToLogFile(month, year, data)
+	if err != nil {
+		return false, err
+	}
+
+	shouldContinue := !currIntervalTime.After(time.Now().Add(interval))
+	return shouldContinue, nil
+}
+
+func (c *Calculator) getRecords(filename string) ([][]string, error) {
+	c.RLock()
+	defer c.RUnlock()
+
+	if !fileExists(filename) {
+		return nil, nil
+	}
+
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	csvReader := csv.NewReader(file)
+	csvReader.TrimLeadingSpace = true
+
+	records, err := csvReader.ReadAll()
+	if err != nil {
+		return nil, err
+	}
+
+	return records, nil
+}
+
+func (c *Calculator) CalculateRateForMonth(
+	month time.Month,
+	year int,
+) (float64, bool, error) {
+	records, err := c.getRecords(c.getLogFilename(month, year))
+	if err != nil {
+		return 0, false, err
+	}
+
+	if len(records) == 0 {
+		return 0, false, ErrNoRecordsFound
+	}
+
+	var isDataMissing bool
+	var total float64
+	for idx, record := range records {
+		dcrBTCCandlestick, err := convertStringArrayToCandlestick(record[:7])
+		if err != nil {
+			return 0, false, err
+		}
+
+		if idx == 0 {
+			currIntervalTime := time.Unix(dcrBTCCandlestick.Timestamp, 0)
+			firstIntervalOfMonth := firstDayOfMonth(month, year).Add(interval)
+			if currIntervalTime.After(firstIntervalOfMonth) {
+				log.Debugf("data is missing because the first record's "+
+					"timestamp (%v) is later than the first interval of the "+
+					"month (%v)", currIntervalTime.Unix(),
+					firstIntervalOfMonth.Unix())
+				isDataMissing = true
+			}
+		} else if idx == len(records)-1 {
+			currIntervalTime := time.Unix(dcrBTCCandlestick.Timestamp, 0)
+			lastIntervalOfMonth := firstDayOfMonth(month, year).AddDate(
+				0, 1, 0).Add(-1 * interval)
+			if currIntervalTime.Before(lastIntervalOfMonth) {
+				log.Debugf("data is missing because the last record's "+
+					"timestamp (%v) is earlier than the last interval of the "+
+					"month (%v)", currIntervalTime.Unix(),
+					lastIntervalOfMonth.Unix())
+				isDataMissing = true
+			}
+		}
+
+		btcUSDCandlestick, err := convertStringArrayToCandlestick(record[7:])
+		if err != nil {
+			return 0, false, err
+		}
+
+		dcrBTCAvg := (dcrBTCCandlestick.Open + dcrBTCCandlestick.Close) / 2
+		btcUSDAvg := (btcUSDCandlestick.Open + btcUSDCandlestick.Close) / 2
+		total += dcrBTCAvg * btcUSDAvg
+	}
+
+	monthStartTime := firstDayOfMonth(month, year).Unix()
+	monthEndTime := firstDayOfMonth(month, year).AddDate(0, 1, 0).Unix()
+	numIntervalsInMonth := (monthStartTime - monthEndTime) /
+		int64(interval/time.Second)
+
+	if len(records) < int(numIntervalsInMonth) {
+		log.Debugf("data is missing because the number of records (%v) is "+
+			"less than the number of intervals in the month (%v)", len(records),
+			numIntervalsInMonth)
+		isDataMissing = true
+	}
+
+	return (total / float64(len(records))), isDataMissing, nil
+}

--- a/cmswww/ratecalc/remote.go
+++ b/cmswww/ratecalc/remote.go
@@ -1,0 +1,240 @@
+package ratecalc
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"strconv"
+	"time"
+
+	"github.com/decred/politeia/util"
+)
+
+type UnmarshalToCandlesticksFunc func([]byte) ([]Candlestick, error)
+type DCRBTCData [][]interface{}
+type BTCUSDData struct {
+	Result XXBTZUSD `json:"result"`
+}
+type XXBTZUSD struct {
+	XXBTZUSD [][]interface{} `json:"XXBTZUSD"`
+}
+
+const (
+	dcrBTCUrl = "https://api.binance.com/api/v1/klines?symbol=DCRBTC&interval=%v&startTime=%v&endTime=%v"
+	btcUSDUrl = "https://api.kraken.com/0/public/OHLC?pair=XBTUSD&interval=%v&since=%v"
+)
+
+var (
+	dcrBTCDataThrottle = time.Tick(time.Second * 5)
+	btcUSDDataThrottle = time.Tick(time.Second * 5)
+
+	dcrBTCIntervalStrs = map[time.Duration]string{
+		(time.Minute * 1):  "1m",
+		(time.Minute * 5):  "5m",
+		(time.Minute * 15): "15m",
+		(time.Minute * 30): "30m",
+		(time.Hour * 1):    "1h",
+		(time.Hour * 4):    "4h",
+	}
+
+	btcUSDIntervalStrs = map[time.Duration]string{
+		(time.Minute * 1):  "1",
+		(time.Minute * 5):  "5",
+		(time.Minute * 15): "15",
+		(time.Minute * 30): "30",
+		(time.Hour * 1):    "60",
+		(time.Hour * 4):    "240",
+	}
+)
+
+func getStringAsFloat(candlestickArr []interface{}, idx int) (float64, error) {
+	val, ok := candlestickArr[idx].(string)
+	if !ok {
+		return 0, fmt.Errorf("data value not recognized as string: %v %v %v",
+			candlestickArr, idx, reflect.TypeOf(candlestickArr[idx]))
+	}
+
+	return strconv.ParseFloat(val, 64)
+}
+
+func getFloat(candlestickArr []interface{}, idx int) (float64, error) {
+	val, ok := candlestickArr[idx].(float64)
+	if !ok {
+		return 0, fmt.Errorf("data value not recognized as float64: %v %v %v",
+			candlestickArr, idx, reflect.TypeOf(candlestickArr[idx]))
+	}
+
+	return val, nil
+}
+
+func (c *Calculator) makeRequest(url string) ([]byte, error) {
+	fmt.Printf("GET %v\n", url)
+	req, err := c.httpClient.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer req.Body.Close()
+
+	responseBody := util.ConvertBodyToByteArray(req.Body, false)
+
+	if req.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%v: %v", req.Status, string(responseBody))
+	}
+
+	return responseBody, nil
+}
+
+func (c *Calculator) getCandlestickData(url string, fn UnmarshalToCandlesticksFunc) ([]Candlestick, error) {
+	response, err := c.makeRequest(url)
+	if err != nil {
+		return nil, err
+	}
+
+	return fn(response)
+}
+
+func (c *Calculator) getDCRBTCData(
+	currIntervalTime time.Time,
+	interval time.Duration,
+) ([]Candlestick, error) {
+	rangeStartTime := currIntervalTime.Unix() * 1000
+	rangeEndTime := currIntervalTime.Add(interval*20).Unix() * 1000
+	url := fmt.Sprintf(dcrBTCUrl, dcrBTCIntervalStrs[interval],
+		rangeStartTime, rangeEndTime)
+
+	<-dcrBTCDataThrottle
+	return c.getCandlestickData(url,
+		func(response []byte) ([]Candlestick, error) {
+			var data DCRBTCData
+			err := json.Unmarshal(response, &data)
+			if err != nil {
+				return nil, err
+			}
+
+			if len(data) == 0 {
+				// No data was returned.
+				return []Candlestick{}, nil
+			}
+
+			candlesticks := make([]Candlestick, 0, len(data))
+			for _, candlestickArr := range data {
+				timestamp, err := getFloat(candlestickArr, 0)
+				if err != nil {
+					return nil, err
+				}
+
+				open, err := getStringAsFloat(candlestickArr, 1)
+				if err != nil {
+					return nil, err
+				}
+
+				high, err := getStringAsFloat(candlestickArr, 2)
+				if err != nil {
+					return nil, err
+				}
+
+				low, err := getStringAsFloat(candlestickArr, 3)
+				if err != nil {
+					return nil, err
+				}
+
+				close, err := getStringAsFloat(candlestickArr, 4)
+				if err != nil {
+					return nil, err
+				}
+
+				volume, err := getStringAsFloat(candlestickArr, 5)
+				if err != nil {
+					return nil, err
+				}
+
+				c := Candlestick{
+					Timestamp:   int64(timestamp) / 1000,
+					Granularity: int64(interval.Minutes()),
+					Open:        open,
+					Close:       close,
+					High:        high,
+					Low:         low,
+					Volume:      volume,
+				}
+
+				candlesticks = append(candlesticks, c)
+			}
+
+			return candlesticks, nil
+		},
+	)
+}
+
+func (c *Calculator) getBTCUSDData(
+	currIntervalTime time.Time,
+	interval time.Duration,
+) ([]Candlestick, error) {
+	// Kraken's range start is exclusive, so subtract by 1 interval.
+	rangeStartTime := currIntervalTime.Add(-1 * interval).Unix()
+	url := fmt.Sprintf(btcUSDUrl, btcUSDIntervalStrs[interval], rangeStartTime)
+
+	<-btcUSDDataThrottle
+	return c.getCandlestickData(url,
+		func(response []byte) ([]Candlestick, error) {
+			var data BTCUSDData
+			err := json.Unmarshal(response, &data)
+			if err != nil {
+				return nil, err
+			}
+
+			if len(data.Result.XXBTZUSD) == 0 {
+				// No data was returned.
+				return []Candlestick{}, nil
+			}
+
+			candlesticks := make([]Candlestick, 0, len(data.Result.XXBTZUSD))
+			for _, candlestickArr := range data.Result.XXBTZUSD {
+				timestamp, err := getFloat(candlestickArr, 0)
+				if err != nil {
+					return nil, err
+				}
+
+				open, err := getStringAsFloat(candlestickArr, 1)
+				if err != nil {
+					return nil, err
+				}
+
+				high, err := getStringAsFloat(candlestickArr, 2)
+				if err != nil {
+					return nil, err
+				}
+
+				low, err := getStringAsFloat(candlestickArr, 3)
+				if err != nil {
+					return nil, err
+				}
+
+				close, err := getStringAsFloat(candlestickArr, 4)
+				if err != nil {
+					return nil, err
+				}
+
+				volume, err := getStringAsFloat(candlestickArr, 6)
+				if err != nil {
+					return nil, err
+				}
+
+				c := Candlestick{
+					Timestamp:   int64(timestamp),
+					Granularity: int64(interval.Minutes()),
+					Open:        open,
+					Close:       close,
+					High:        high,
+					Low:         low,
+					Volume:      volume,
+				}
+
+				candlesticks = append(candlesticks, c)
+			}
+
+			return candlesticks, nil
+		},
+	)
+}

--- a/cmswww/ratecalc/remote.go
+++ b/cmswww/ratecalc/remote.go
@@ -69,7 +69,7 @@ func getFloat(candlestickArr []interface{}, idx int) (float64, error) {
 }
 
 func (c *Calculator) makeRequest(url string) ([]byte, error) {
-	fmt.Printf("GET %v\n", url)
+	log.Tracef("GET %v\n", url)
 	req, err := c.httpClient.Get(url)
 	if err != nil {
 		return nil, err

--- a/cmswww/routes.go
+++ b/cmswww/routes.go
@@ -185,4 +185,6 @@ func (c *cmswww) SetupRoutes() {
 		v1.UpdateInvoicePayment{}, permissionAdmin, true)
 	c.addGetRoute(v1.RouteUsers, c.HandleUsers, v1.Users{},
 		permissionAdmin, false)
+	c.addGetRoute(v1.RouteRate, c.HandleRate, v1.Rate{},
+		permissionAdmin, false)
 }


### PR DESCRIPTION
This commit adds logic to pull DCR-BTC and BTC-USD price data from
the Binance and Kraken APIs (respectively) for 15 minute intervals
and store them in a file for the current month. It also supports
pulling data for the previous month if the current time is within the
first 5 days of the current month.

It also adds a route to fetch the DCR-USD rate, which reads all records
for the given month from the data file and calculates the rate by first
multiplying the average between the Open and Close values for a DCR-BTC
candlestick with the average between the Open and Close values for the
corresponding BTC-USD candlestick with the same timestamp. The logic
then averages DCR-USD values for all intervals in a given month and
returns it as the DCR-USD rate for the month.