### PR TITLE
config: Removed stray 'i'

### DIFF
--- a/cmswww/sample-cmswww.conf
+++ b/cmswww/sample-cmswww.conf
@@ -1,4 +1,4 @@
-i[Application Options]
+[Application Options]
 
 ; ------------------------------------------------------------------------------
 ; Data settings


### PR DESCRIPTION
Removed an 'i' at the start of the document that I think was not supposed to be there.