### PR TITLE
core: Provide task method for initialising database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *.dylib
 cmswww/cmswww
+cmswww/cmd/cmswwwcli/cmswwwcli
 
 # Test binary, build with `go test -c`
 *.test

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ Make sure each of these are in the PATH.
 CockroachDB is used by cmswww as storage for users, invoices and other data. Some data,
 such as invoices, are pulled from politeiad when cmswww starts and are added to the database.
 
-To set up CockroachDB for use with cmswww, follow these steps:
+To set up CockroachDB for use with cmswww, you can either do this manually or, on Linux, using go-task if you prefer.
+
+##### Manual method
 
   1. Install [CockroachDB](https://www.cockroachlabs.com/docs/stable/install-cockroachdb-windows.html).
 
@@ -62,6 +64,19 @@ To set up CockroachDB for use with cmswww, follow these steps:
 
           cd <install dir>
           cockroach start --host=localhost --http-host=localhost --certs-dir="~/.cmswww/data/testnet3/cockroachdb"
+
+##### Task method
+
+  1.  Ensure that [task](https://taskfile.org) is installed)
+
+  2.  Run ```task init_cdb```
+
+This will run through all the steps described under the manual method above, 
+choosing default folders for the data.  Running ```task init_cdb``` a second
+time will delete the database and rerun steps again.
+
+Run ```task -l``` to see other commands available.  Some additional commands
+may require that politeiad or cmswww are available on your system.
 
 #### 2. Clone this repository and [decred/politeia](https://github.com/decred/politeia).
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,55 @@
+version: '2'
+
+vars:
+  INSTALL_DIR: "{{env \"HOME\"}}/cmswww"
+  DATA_DIR: "{{env \"HOME\"}}/.cmswww/data/{{.NAME}}/cockroachdb/data"
+  # Name is used to give an identity for where to create persistent storage
+  # items, and has been set in this instance to the name of the network we
+  # connect to
+  NAME: testnet3
+
+tasks:
+  dataload:
+    desc: Runs cmswwwdataload to fill out database with some sample data
+    cmds:
+      - cmswwwdataload --verbose --deletedata
+
+  init_cdb:
+    desc: Deletes (if necessary) and (re)creates database ready for use
+    cmds:
+      - task: quit_cdb
+      - task: reset_cdb
+      - rm -rf ~/.cmswww/data/{{.NAME}}/cockroachdb
+      - mkdir -p ~/.cmswww/data/{{.NAME}}/cockroachdb
+      - mkdir -p {{.INSTALL_DIR}}
+      - cockroach cert create-ca --certs-dir="$(echo ~)/.cmswww/data/{{.NAME}}/cockroachdb" --ca-key="{{.INSTALL_DIR}}/ca.key" --allow-ca-key-reuse
+      - cockroach cert create-client root --certs-dir="$(echo ~)/.cmswww/data/{{.NAME}}/cockroachdb" --ca-key="{{.INSTALL_DIR}}/ca.key"
+      - cockroach cert create-node localhost --certs-dir="$(echo ~)/.cmswww/data/{{.NAME}}/cockroachdb" --ca-key="{{.INSTALL_DIR}}/ca.key"
+      - task: start_cdb
+      - sleep 1
+      - cockroach user set cmswwwuser --certs-dir="$(echo ~)/.cmswww/data/{{.NAME}}/cockroachdb"
+      - cockroach cert create-client cmswwwuser --certs-dir="$(echo ~)/.cmswww/data/{{.NAME}}/cockroachdb" --ca-key="{{.INSTALL_DIR}}/ca.key"
+      - cockroach sql --certs-dir="$(echo ~)/.cmswww/data/{{.NAME}}/cockroachdb" -e 'CREATE DATABASE cmswww'
+      - cockroach sql --certs-dir="$(echo ~)/.cmswww/data/{{.NAME}}/cockroachdb" -e 'GRANT ALL ON DATABASE cmswww TO cmswwwuser'
+      - cockroach sql --user=cmswwwuser --certs-dir="$(echo ~)/.cmswww/data/{{.NAME}}/cockroachdb" -e 'GRANT ALL ON DATABASE cmswww TO cmswwwuser'
+
+  start_cdb:
+    desc: Start database
+    cmds:
+      - cockroach start --background --store={{.DATA_DIR}} --host=localhost --http-host=localhost --certs-dir="$(echo ~)/.cmswww/data/{{.NAME}}/cockroachdb" &
+
+  quit_cdb:
+    desc: Stops database
+    cmds:
+      - cmd: cockroach quit --certs-dir="$(echo ~)/.cmswww/data/{{.NAME}}/cockroachdb"
+        ignore_error: true
+  
+  reset_cdb:
+    desc: Deletes database data from system
+    cmds:
+      - rm -rf {{.DATA_DIR}}
+
+  vendor:
+    desc: Vendor go modules
+    cmds:
+      - GO111MODULE=on go mod vendor


### PR DESCRIPTION
Implement using go-task to make it easier to set up and tear down the
database with defaults.  Encoding these steps in the code will make it
easier for future developers to get up and running.  Documentation
updated to reflect new optional method.

The Taskfile.yml may be expanded with further useful commands later.

I have only tested this on a Linux system, and I suspect it won't work on other operating systems.